### PR TITLE
Rename bssh to aws s3 copy workflow

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -18,12 +18,12 @@ export const SEQUENCE_RUN_MANAGER_EVENT_STATUS = 'SUCCEEDED';
 /* BSSH Fastq Copy to AWS Constants */
 export const WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE = 'WorkflowRunStateChange';
 export const WORKFLOW_MANAGER_EVENT_SOURCE = 'orcabus.workflowmanager';
-export const BSSH_FASTQ_TO_AWS_COPY_WORKFLOW_NAME = 'bssh-fastq-to-aws-copy';
-export const BSSH_FASTQ_TO_AWS_COPY_STATUS = 'SUCCEEDED';
+export const BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME = 'bssh-to-aws-s3';
+export const BSSH_TO_AWS_S3_COPY_STATUS = 'SUCCEEDED';
 
 /* Local stack constants */
-export const STACK_EVENT_SOURCE = 'orcabus.fastqglue';
-export const SFN_PREFIX = 'fastq-glue-';
+export const STACK_SOURCE = 'orcabus.fastqglue';
+export const STACK_PREFIX = 'fastq-glue';
 
 /* Event Details */
 export const FASTQ_LIST_ROWS_ADDED_EVENT_DETAIL_TYPE = 'FastqListRowsAdded';

--- a/infrastructure/stage/event-rules/index.ts
+++ b/infrastructure/stage/event-rules/index.ts
@@ -11,14 +11,15 @@ import { Rule } from 'aws-cdk-lib/aws-events';
 import * as events from 'aws-cdk-lib/aws-events';
 import { Construct } from 'constructs';
 import {
-  BSSH_FASTQ_TO_AWS_COPY_STATUS,
-  BSSH_FASTQ_TO_AWS_COPY_WORKFLOW_NAME,
+  BSSH_TO_AWS_S3_COPY_STATUS,
+  BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME,
   FASTQ_LIST_ROWS_ADDED_EVENT_DETAIL_TYPE,
   READ_SETS_ADDED_EVENT_DETAIL_TYPE,
   SEQUENCE_RUN_MANAGER_EVENT_SOURCE,
   SEQUENCE_RUN_MANAGER_EVENT_STATUS,
   SEQUENCE_RUN_MANAGER_STATE_CHANGE_EVENT_DETAIL_TYPE,
-  STACK_EVENT_SOURCE,
+  STACK_PREFIX,
+  STACK_SOURCE,
   WORKFLOW_MANAGER_EVENT_SOURCE,
   WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE,
 } from '../constants';
@@ -33,7 +34,7 @@ function buildSequenceRunManagerStateChangeEventRule(
   props: SequenceRunManagerRuleProps
 ): Rule {
   return new events.Rule(scope, props.ruleName, {
-    ruleName: props.ruleName,
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: {
       source: [props.eventSource],
       detailType: [props.eventDetailType],
@@ -50,7 +51,7 @@ function buildWorkflowRunStateChangeEventRule(
   props: WorkflowRunStateChangeRuleProps
 ): Rule {
   return new events.Rule(scope, props.ruleName, {
-    ruleName: props.ruleName,
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: {
       source: [props.eventSource],
       detailType: [props.eventDetailType],
@@ -68,7 +69,7 @@ function buildFastqGlueFastqListRowsAddedEventRule(
   props: FastqListRowAddedRuleProps
 ): Rule {
   return new events.Rule(scope, props.ruleName, {
-    ruleName: props.ruleName,
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: {
       source: [props.eventSource],
       detailType: [props.eventDetailType],
@@ -85,7 +86,7 @@ function buildFastqGlueReadSetsAddedEventRule(
   props: ReadSetsAddedRuleProps
 ): Rule {
   return new events.Rule(scope, props.ruleName, {
-    ruleName: props.ruleName,
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: {
       source: [props.eventSource],
       detailType: [props.eventDetailType],
@@ -127,8 +128,8 @@ export function buildAllEventRules(
             eventSource: WORKFLOW_MANAGER_EVENT_SOURCE,
             eventBus: props.eventBus,
             eventDetailType: WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE,
-            eventStatus: BSSH_FASTQ_TO_AWS_COPY_STATUS,
-            workflowName: BSSH_FASTQ_TO_AWS_COPY_WORKFLOW_NAME,
+            eventStatus: BSSH_TO_AWS_S3_COPY_STATUS,
+            workflowName: BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME,
           }),
         });
         break;
@@ -138,7 +139,7 @@ export function buildAllEventRules(
           ruleName: ruleName,
           ruleObject: buildFastqGlueFastqListRowsAddedEventRule(scope, {
             ruleName: ruleName,
-            eventSource: STACK_EVENT_SOURCE,
+            eventSource: STACK_SOURCE,
             eventBus: props.eventBus,
             eventDetailType: FASTQ_LIST_ROWS_ADDED_EVENT_DETAIL_TYPE,
           }),
@@ -150,7 +151,7 @@ export function buildAllEventRules(
           ruleName: ruleName,
           ruleObject: buildFastqGlueReadSetsAddedEventRule(scope, {
             ruleName: ruleName,
-            eventSource: STACK_EVENT_SOURCE,
+            eventSource: STACK_SOURCE,
             eventBus: props.eventBus,
             eventDetailType: READ_SETS_ADDED_EVENT_DETAIL_TYPE,
           }),

--- a/infrastructure/stage/event-targets/index.ts
+++ b/infrastructure/stage/event-targets/index.ts
@@ -24,8 +24,8 @@ function buildBsshFastqCopySucceededToFastqSetAddReadSetEventBridgeTarget(
   props.eventBridgeRuleObj.addTarget(
     new eventsTargets.SfnStateMachine(props.stateMachineObj, {
       input: RuleTargetInput.fromObject({
-        outputUri: EventField.fromPath('$.detail.payload.data.outputs.outputUri'),
-        instrumentRunId: EventField.fromPath('$.detail.payload.data.outputs.instrumentRunId'),
+        outputUri: EventField.fromPath('$.detail.payload.data.engineParameters.outputUri'),
+        instrumentRunId: EventField.fromPath('$.detail.payload.data.tags.instrumentRunId'),
       }),
     })
   );

--- a/infrastructure/stage/step-functions/index.ts
+++ b/infrastructure/stage/step-functions/index.ts
@@ -25,8 +25,8 @@ import {
   SAMPLESHEET_SHOWER_COMPLETE_STATUS,
   SAMPLESHEET_SHOWER_STARTING_STATUS,
   SAMPLESHEET_SHOWER_STATE_CHANGE_DETAIL_TYPE,
-  SFN_PREFIX,
-  STACK_EVENT_SOURCE,
+  STACK_PREFIX,
+  STACK_SOURCE,
   STACKY_FASTQ_LIST_ROW_SHOWER_STATE_CHANGE,
   STACKY_FASTQ_LIST_ROW_STATE_CHANGE,
   START_SAMPLESHEET_SHOWER_PAYLOAD_VERSION,
@@ -75,7 +75,7 @@ function createStateMachineDefinitionSubstitutions(props: BuildSfnProps): {
     READ_SETS_ADDED_EVENT_DETAIL_TYPE;
 
   /* Substitute the event source in the state machine definition */
-  definitionSubstitutions['__stack_event_source__'] = STACK_EVENT_SOURCE;
+  definitionSubstitutions['__stack_event_source__'] = STACK_SOURCE;
 
   /* Stacky glue substitutions - that we will oneday be able to delete */
   definitionSubstitutions['__samplesheet_shower_started_detail_type__'] =
@@ -196,7 +196,7 @@ function buildStepFunction(scope: Construct, props: BuildSfnProps): SfnObject {
 
   /* Create the state machine definition substitutions */
   const stateMachine = new sfn.StateMachine(scope, props.stateMachineName, {
-    stateMachineName: `${SFN_PREFIX}${props.stateMachineName}`,
+    stateMachineName: `${STACK_PREFIX}--${props.stateMachineName}`,
     definitionBody: sfn.DefinitionBody.fromFile(
       path.join(STEP_FUNCTIONS_DIR, sfnNameToSnakeCase + '_sfn_template.asl.json')
     ),


### PR DESCRIPTION
Add stack prefixes to event rules, and handle new bclconvert payload