### PR TITLE
Increases memory for specific Lambda functions

### DIFF
--- a/infrastructure/stage/lambdas/index.ts
+++ b/infrastructure/stage/lambdas/index.ts
@@ -32,6 +32,7 @@ export function buildLambdaFunction(scope: Construct, props: BuildLambdaProps): 
     handler: 'handler',
     timeout: Duration.seconds(60),
     includeOrcabusApiToolsLayer: lambdaRequirementsMap.needsOrcabusApiToolsLayer,
+    memorySize: lambdaRequirementsMap.needsMoreMemory ? 1024 : undefined,
   });
 
   /* Do we need the bssh tools layer? */

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -44,6 +44,9 @@ export interface LambdaRequirementProps {
 
   /* Needs orcabus api tools layer */
   needsOrcabusApiToolsLayer?: boolean;
+
+  /* Needs More memory */
+  needsMoreMemory?: boolean;
 }
 
 export interface BuildLambdasProps {
@@ -75,6 +78,7 @@ export const lambdaToRequirementsMap: LambdaToRequirementsMapType = {
   },
   createFastqSetObject: {
     needsOrcabusApiToolsLayer: true,
+    needsMoreMemory: true,
   },
   // Fastq add readset related
   addReadSetsToFastqObjects: {


### PR DESCRIPTION
Resolves #34 

-----
Purpose
-----
*   Introduces a mechanism to allocate more memory to Lambdas with higher resource demands, addressing potential performance bottlenecks or timeouts.

-----
Changes
-----
*   Adds a `needsMoreMemory` flag to the Lambda requirement properties.
*   Configures the Lambda builder to provision 1024MB of memory when `needsMoreMemory` is enabled for a given function.
*   Enables increased memory for the `createFastqSetObject` Lambda, optimizing its execution.