### PR TITLE
Enables configurable Lambda function timeouts

### DIFF
--- a/app/step-function-templates/fastq_set_add_read_set_sfn_template.asl.json
+++ b/app/step-function-templates/fastq_set_add_read_set_sfn_template.asl.json
@@ -237,7 +237,8 @@
               "fileNamesList": "{% $states.context.Map.Item.Value.fileNamesList %}",
               "demuxData": "{% $states.context.Map.Item.Value.demuxData %}"
             },
-            "Output": {}
+            "Output": {},
+            "MaxConcurrency": 1
           }
         }
       },

--- a/infrastructure/stage/lambdas/index.ts
+++ b/infrastructure/stage/lambdas/index.ts
@@ -30,7 +30,9 @@ export function buildLambdaFunction(scope: Construct, props: BuildLambdaProps): 
     architecture: lambda.Architecture.ARM_64,
     index: lambdaNameToSnakeCase + '.py',
     handler: 'handler',
-    timeout: Duration.seconds(60),
+    timeout: lambdaRequirementsMap.needsLongerTimeout
+      ? Duration.seconds(300)
+      : Duration.seconds(60),
     includeOrcabusApiToolsLayer: lambdaRequirementsMap.needsOrcabusApiToolsLayer,
     memorySize: lambdaRequirementsMap.needsMoreMemory ? 1024 : undefined,
   });

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -47,6 +47,9 @@ export interface LambdaRequirementProps {
 
   /* Needs More memory */
   needsMoreMemory?: boolean;
+
+  /* Needs Longer timeout */
+  needsLongerTimeout?: boolean;
 }
 
 export interface BuildLambdasProps {
@@ -79,6 +82,7 @@ export const lambdaToRequirementsMap: LambdaToRequirementsMapType = {
   createFastqSetObject: {
     needsOrcabusApiToolsLayer: true,
     needsMoreMemory: true,
+    needsLongerTimeout: true,
   },
   // Fastq add readset related
   addReadSetsToFastqObjects: {


### PR DESCRIPTION
-----
infrastructure
-----
* Introduces a `needsLongerTimeout` flag to allow specific Lambda functions to have extended timeouts.
* Configures the `createFastqSetObject` Lambda with a 300-second timeout to accommodate longer processing tasks.

-----
app
-----
* Sets `MaxConcurrency` to 1 for the `RunAddReadSetsMap` state in the `fastq_set_add_read_set_sfn_template`.