### PR TITLE
Adds workflow for missing fingerprint generation

### DIFF
--- a/app/lambdas/find_missing_fingerprints_py/find_missing_fingerprints.py
+++ b/app/lambdas/find_missing_fingerprints_py/find_missing_fingerprints.py
@@ -4,6 +4,7 @@
 Find missing fingerprints
 
 Given an instrument run id, query the fastq manager for
+fastq set IDs missing somalier fingerprints.
 """
 
 # Standard imports

--- a/app/lambdas/find_missing_fingerprints_py/find_missing_fingerprints.py
+++ b/app/lambdas/find_missing_fingerprints_py/find_missing_fingerprints.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+"""
+Find missing fingerprints
+
+Given an instrument run id, query the fastq manager for
+"""
+
+# Standard imports
+from typing import List, Dict
+
+# Layers
+from orcabus_api_tools.fastq import (
+    get_fastqs_in_instrument_run_id,
+    get_fastq_set
+)
+
+
+def handler(event, context) -> Dict[str, List[str]]:
+    """
+    Find missing fingerprints
+    """
+
+    # Get inputs
+    instrument_run_id = event['instrumentRunId']
+
+    # Get fastq sets
+    fastq_set_id_list = list(set(
+        list(filter(
+            lambda fastq_iter_map_: fastq_iter_map_ is not None,
+            list(map(
+                lambda fastq_iter_: (
+                    fastq_iter_.get('fastqSetId')
+                    if fastq_iter_.get('fastqSetId')
+                    else None
+                ),
+                get_fastqs_in_instrument_run_id(instrument_run_id),
+            ))
+        ))
+    ))
+
+    # Filter to just those with a missing somalier entry
+    fastq_set_id_with_missing_fingerprints = []
+    for fastq_set_id_iter_ in fastq_set_id_list:
+        if get_fastq_set(fastq_set_id_iter_).get('somalier') is None:
+            fastq_set_id_with_missing_fingerprints.append(fastq_set_id_iter_)
+
+    return {
+        "fastqSetIdList": fastq_set_id_with_missing_fingerprints
+    }

--- a/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
+++ b/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
@@ -18,14 +18,20 @@ def handler(event, context):
     :return:
     """
 
+    # Get inputs
     fastq_set_id = event['fastqSetId']
     reference_name = event['referenceName']
-    bam_uri = event['bamUri']
+    bam_uri = event.get('bamUri', None)
 
+    # Run fingerprint extraction
     run_extract_fingerprint(
-        fastq_set_id=fastq_set_id,
-        reference_name=reference_name,
-        bam_uri=bam_uri
+        **dict(filter(
+            lambda kv_iter_: kv_iter_ is not None,
+            {
+                "fastq_set_id": fastq_set_id,
+                "reference_name": reference_name,
+                "bam_uri": bam_uri,
+            }.items()
+        ))
     )
 
-    return {}

--- a/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
+++ b/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
@@ -26,7 +26,7 @@ def handler(event, context):
     # Run fingerprint extraction
     run_extract_fingerprint(
         **dict(filter(
-            lambda kv_iter_: kv_iter_ is not None,
+            lambda kv_iter_: kv_iter_[1] is not None,
             {
                 "fastq_set_id": fastq_set_id,
                 "reference_name": reference_name,

--- a/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
+++ b/app/lambdas/run_extract_fingerprint_py/run_extract_fingerprint.py
@@ -34,4 +34,3 @@ def handler(event, context):
             }.items()
         ))
     )
-

--- a/app/step-function-templates/add_missing_fingerprints_sfn_template.asl.json
+++ b/app/step-function-templates/add_missing_fingerprints_sfn_template.asl.json
@@ -38,7 +38,7 @@
         }
       ],
       "Output": {
-        "fastqSetIdList": "{% $states.input.fastqSetIdList %}"
+        "fastqSetIdList": "{% $states.result.Payload.fastqSetIdList %}"
       },
       "Next": "Generate fingerprints for missing fastq sets (batched)"
     },

--- a/app/step-function-templates/add_missing_fingerprints_sfn_template.asl.json
+++ b/app/step-function-templates/add_missing_fingerprints_sfn_template.asl.json
@@ -1,0 +1,106 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Set vars",
+  "States": {
+    "Set vars": {
+      "Type": "Pass",
+      "Next": "Wait one day for processing",
+      "Assign": {
+        "instrumentRunId": "{% $states.input.instrumentRunId %}"
+      }
+    },
+    "Wait one day for processing": {
+      "Type": "Wait",
+      "Seconds": "{% /* One whole day */ 60 * 60 * 24 %}",
+      "Next": "Find fastq sets without a fingerprint"
+    },
+    "Find fastq sets without a fingerprint": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Arguments": {
+        "FunctionName": "${__find_missing_fingerprints_lambda_function_arn__}",
+        "Payload": {
+          "instrumentRunId": "{% $instrumentRunId %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Output": {
+        "fastqSetIdList": "{% $states.input.fastqSetIdList %}"
+      },
+      "Next": "Generate fingerprints for missing fastq sets (batched)"
+    },
+    "Generate fingerprints for missing fastq sets (batched)": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD"
+        },
+        "StartAt": "Generate fingerprints for missing fastq sets",
+        "States": {
+          "Generate fingerprints for missing fastq sets": {
+            "Type": "Map",
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "INLINE"
+              },
+              "StartAt": "Run extract fingerprint",
+              "States": {
+                "Run extract fingerprint": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:states:::lambda:invoke",
+                  "Arguments": {
+                    "Payload": {
+                      "fastqSetId": "{% $states.input %}",
+                      "referenceName": "${__default_reference_name__}"
+                    },
+                    "FunctionName": "${__run_extract_fingerprint_lambda_function_arn__}"
+                  },
+                  "Retry": [
+                    {
+                      "ErrorEquals": [
+                        "Lambda.ServiceException",
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException",
+                        "Lambda.TooManyRequestsException"
+                      ],
+                      "IntervalSeconds": 1,
+                      "MaxAttempts": 3,
+                      "BackoffRate": 2,
+                      "JitterStrategy": "FULL"
+                    }
+                  ],
+                  "End": true
+                }
+              }
+            },
+            "End": true,
+            "Items": "{% $states.input.Items %}",
+            "MaxConcurrency": 1
+          }
+        }
+      },
+      "End": true,
+      "Label": "Generatefingerprintsformissingfastqsetsbatched",
+      "MaxConcurrency": 1,
+      "Items": "{% $states.input.fastqSetIdList %}",
+      "ItemBatcher": {
+        "MaxItemsPerBatch": 10
+      }
+    }
+  },
+  "QueryLanguage": "JSONata"
+}

--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -41,6 +41,9 @@ export const FASTQ_LIST_ROWS_ADDED_EVENT_DETAIL_TYPE = 'FastqListRowsAdded';
 export const READ_SETS_ADDED_EVENT_DETAIL_TYPE = 'ReadSetsAdded';
 export const SRM_CLEANUP_EVENT_DETAIL_TYPE = 'SrmFailureCleanupFastqCompleted';
 
+/* Somalier constants */
+export const DEFAULT_REFERENCE_NAME = 'hg38';
+
 /*
 AWS S3 Resources differ between environments
 */

--- a/infrastructure/stage/event-rules/index.ts
+++ b/infrastructure/stage/event-rules/index.ts
@@ -3,6 +3,7 @@ import {
   EventBridgeRuleObject,
   EventBridgeRulesProps,
   MultiWorkflowRunStateChangeRuleProps,
+  ReadSetsAddedRuleProps,
   SequenceRunSampleSheetStateChangeRuleProps,
   SequenceRunStateChangeRuleProps,
   WorkflowRunStateChangeRuleProps,
@@ -15,12 +16,12 @@ import {
   BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME,
   DRAGEN_TSO500_CTDNA_WORKFLOW_NAME,
   DRAGEN_WGTS_DNA_WORKFLOW_NAME,
-  DRAGEN_WGTS_RNA_WORKFLOW_NAME,
+  DRAGEN_WGTS_RNA_WORKFLOW_NAME, READ_SETS_ADDED_EVENT_DETAIL_TYPE,
   SEQUENCE_RUN_MANAGER_EVENT_SOURCE,
   SEQUENCE_RUN_MANAGER_FAILURE_STATUS,
   SEQUENCE_RUN_MANAGER_SAMPLESHEET_CHANGE_DETAIL_TYPE,
   SEQUENCE_RUN_MANAGER_STATE_CHANGE_DETAIL_TYPE,
-  STACK_PREFIX,
+  STACK_PREFIX, STACK_SOURCE,
   WORKFLOW_MANAGER_EVENT_SOURCE,
   WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE,
 } from '../constants';
@@ -76,6 +77,20 @@ function buildWorkflowRunStateChangeEventRule(
           name: [{ 'equals-ignore-case': props.workflowName }],
         },
       },
+    },
+    eventBus: props.eventBus,
+  });
+}
+
+function buildReadSetsAddedRule(
+  scope: Construct,
+  props: ReadSetsAddedRuleProps
+): Rule {
+  return new events.Rule(scope, props.ruleName, {
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
+    eventPattern: {
+      source: [props.eventSource],
+      detailType: [props.eventDetailType],
     },
     eventBus: props.eventBus,
   });
@@ -149,6 +164,19 @@ export function buildAllEventRules(
             eventDetailType: WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE,
             eventStatus: BSSH_TO_AWS_S3_COPY_STATUS,
             workflowName: BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME,
+          }),
+        });
+        break;
+      }
+      /* listenReadsetsAddedRule */
+      case 'listenReadsetsAddedRule': {
+        eventBridgeRuleObjects.push({
+          ruleName: ruleName,
+          ruleObject: buildReadSetsAddedRule(scope, {
+            ruleName: ruleName,
+            eventSource: STACK_SOURCE, // This is from within!
+            eventDetailType: READ_SETS_ADDED_EVENT_DETAIL_TYPE,
+            eventBus: props.eventBus,
           }),
         });
         break;

--- a/infrastructure/stage/event-rules/index.ts
+++ b/infrastructure/stage/event-rules/index.ts
@@ -16,12 +16,14 @@ import {
   BSSH_TO_AWS_S3_COPY_WORKFLOW_NAME,
   DRAGEN_TSO500_CTDNA_WORKFLOW_NAME,
   DRAGEN_WGTS_DNA_WORKFLOW_NAME,
-  DRAGEN_WGTS_RNA_WORKFLOW_NAME, READ_SETS_ADDED_EVENT_DETAIL_TYPE,
+  DRAGEN_WGTS_RNA_WORKFLOW_NAME,
+  READ_SETS_ADDED_EVENT_DETAIL_TYPE,
   SEQUENCE_RUN_MANAGER_EVENT_SOURCE,
   SEQUENCE_RUN_MANAGER_FAILURE_STATUS,
   SEQUENCE_RUN_MANAGER_SAMPLESHEET_CHANGE_DETAIL_TYPE,
   SEQUENCE_RUN_MANAGER_STATE_CHANGE_DETAIL_TYPE,
-  STACK_PREFIX, STACK_SOURCE,
+  STACK_PREFIX,
+  STACK_SOURCE,
   WORKFLOW_MANAGER_EVENT_SOURCE,
   WORKFLOW_RUN_STATE_CHANGE_EVENT_DETAIL_TYPE,
 } from '../constants';
@@ -82,10 +84,7 @@ function buildWorkflowRunStateChangeEventRule(
   });
 }
 
-function buildReadSetsAddedRule(
-  scope: Construct,
-  props: ReadSetsAddedRuleProps
-): Rule {
+function buildReadSetsAddedRule(scope: Construct, props: ReadSetsAddedRuleProps): Rule {
   return new events.Rule(scope, props.ruleName, {
     ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: {

--- a/infrastructure/stage/event-rules/interfaces.ts
+++ b/infrastructure/stage/event-rules/interfaces.ts
@@ -43,7 +43,7 @@ export interface EventBridgeRulePropsWithStatus extends EventBridgeRuleProps {
   eventStatus: string;
 }
 
-export type ReadSetsAddedRuleProps = EventBridgeRuleProps
+export type ReadSetsAddedRuleProps = EventBridgeRuleProps;
 
 export interface WorkflowRunStateChangeRuleProps extends EventBridgeRulePropsWithStatus {
   /* We also require the workflow name for both rules */

--- a/infrastructure/stage/event-rules/interfaces.ts
+++ b/infrastructure/stage/event-rules/interfaces.ts
@@ -7,6 +7,8 @@ export type EventBridgeNameList =
   | 'listenSrmStateChangeFailureRule'
   /* Listen to bssh Fastq Copy Ready rule */
   | 'listenBsshFastqCopySucceededRule'
+  /* Listen to readsets added rule */
+  | 'listenReadsetsAddedRule'
   /* Dragen WGTS DNA / TSO500 ctDNA */
   | 'listenWorkflowWithBamRule';
 
@@ -17,6 +19,8 @@ export const eventBridgeNameList: EventBridgeNameList[] = [
   'listenSrmStateChangeFailureRule',
   /* Listen to bssh Fastq Copy Ready rule */
   'listenBsshFastqCopySucceededRule',
+  /* Listen to readsets added rule */
+  'listenReadsetsAddedRule',
   /* Listen to Workflow with Bam rule */
   'listenWorkflowWithBamRule',
 ];
@@ -38,6 +42,8 @@ export interface EventBridgeRulePropsWithStatus extends EventBridgeRuleProps {
   /* Event Status */
   eventStatus: string;
 }
+
+export type ReadSetsAddedRuleProps = EventBridgeRuleProps
 
 export interface WorkflowRunStateChangeRuleProps extends EventBridgeRulePropsWithStatus {
   /* We also require the workflow name for both rules */

--- a/infrastructure/stage/event-targets/index.ts
+++ b/infrastructure/stage/event-targets/index.ts
@@ -31,7 +31,7 @@ function buildSrmFailureToFastqSetGenerationSfnEventBridgeTarget(
 }
 
 function buildAddMissingFingerprintsSfnEventBridgeTarget(
-    props: AddSfnAsEventBridgeTargetProps
+  props: AddSfnAsEventBridgeTargetProps
 ): void {
   props.eventBridgeRuleObj.addTarget(
     new eventsTargets.SfnStateMachine(props.stateMachineObj, {

--- a/infrastructure/stage/event-targets/index.ts
+++ b/infrastructure/stage/event-targets/index.ts
@@ -30,6 +30,18 @@ function buildSrmFailureToFastqSetGenerationSfnEventBridgeTarget(
   );
 }
 
+function buildAddMissingFingerprintsSfnEventBridgeTarget(
+    props: AddSfnAsEventBridgeTargetProps
+): void {
+  props.eventBridgeRuleObj.addTarget(
+    new eventsTargets.SfnStateMachine(props.stateMachineObj, {
+      input: RuleTargetInput.fromObject({
+        instrumentRunId: EventField.fromPath('$.detail.instrumentRunId'),
+      }),
+    })
+  );
+}
+
 function buildBsshFastqCopySucceededToFastqSetAddReadSetEventBridgeTarget(
   props: AddSfnAsEventBridgeTargetProps
 ): void {
@@ -111,6 +123,19 @@ export function buildAllEventBridgeTargets(props: EventBridgeTargetsProps) {
           )?.ruleObject,
           stateMachineObj: props.stepFunctionObjects.find(
             (eventBridgeObject) => eventBridgeObject.stateMachineName === 'triggerSomalierExtract'
+          )?.stateMachineObj,
+        });
+        break;
+      }
+
+      // Post-post analysis events
+      case 'listenReadSetsAddedToAddMissingFingerprintsSfn': {
+        buildAddMissingFingerprintsSfnEventBridgeTarget(<AddSfnAsEventBridgeTargetProps>{
+          eventBridgeRuleObj: props.eventBridgeRuleObjects.find(
+            (eventBridgeObject) => eventBridgeObject.ruleName === 'listenReadsetsAddedRule'
+          )?.ruleObject,
+          stateMachineObj: props.stepFunctionObjects.find(
+            (eventBridgeObject) => eventBridgeObject.stateMachineName === 'addMissingFingerprints'
           )?.stateMachineObj,
         });
         break;

--- a/infrastructure/stage/event-targets/interfaces.ts
+++ b/infrastructure/stage/event-targets/interfaces.ts
@@ -11,7 +11,9 @@ export type EventBridgeTargetsNameList =
   // Post BCLConvert - Pre Staging
   | 'bsshFastqCopySucceededToFastqSetAddReadSetSfn'
   // Post Staging - Analysis
-  | 'listenWorkflowWithBamRuleToTriggerSomalierExtractSfn';
+  | 'listenWorkflowWithBamRuleToTriggerSomalierExtractSfn'
+  // Post-Post - Analysis
+  | 'listenReadSetsAddedToAddMissingFingerprintsSfn';
 
 export const eventBridgeTargetsNameList: Array<EventBridgeTargetsNameList> = [
   // Pre BCLConvert
@@ -22,6 +24,8 @@ export const eventBridgeTargetsNameList: Array<EventBridgeTargetsNameList> = [
   'bsshFastqCopySucceededToFastqSetAddReadSetSfn',
   // Post Staging - Analysis
   'listenWorkflowWithBamRuleToTriggerSomalierExtractSfn',
+  // Post-Post - Analysis
+  'listenReadSetsAddedToAddMissingFingerprintsSfn',
 ];
 
 export interface AddSfnAsEventBridgeTargetProps {

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -17,6 +17,7 @@ export type LambdaNameList =
   | 'getFileNamesFromFastqListCsv'
   | 'getSampleDemultiplexStats'
   // Extract fingerprint related
+  | 'findMissingFingerprints'
   | 'getBamByLibraryId'
   | 'runExtractFingerprint'
   | 'getFastqSetIdByLibrary';
@@ -36,6 +37,7 @@ export const lambdaNameList: Array<LambdaNameList> = [
   'getFileNamesFromFastqListCsv',
   'getSampleDemultiplexStats',
   // Extract fingerprint related
+  'findMissingFingerprints',
   'getBamByLibraryId',
   'runExtractFingerprint',
   'getFastqSetIdByLibrary',
@@ -117,6 +119,9 @@ export const lambdaToRequirementsMap: LambdaToRequirementsMapType = {
     needsAwsReadAccess: true,
   },
   // Extract fingerprint related
+  findMissingFingerprints: {
+    needsOrcabusApiToolsLayer: true,
+  },
   getBamByLibraryId: {
     needsOrcabusApiToolsLayer: true,
   },

--- a/infrastructure/stage/step-functions/index.ts
+++ b/infrastructure/stage/step-functions/index.ts
@@ -9,6 +9,7 @@ import {
 import { camelCaseToSnakeCase } from '../utils';
 import { Construct } from 'constructs';
 import {
+  DEFAULT_REFERENCE_NAME,
   FASTQ_LIST_ROWS_ADDED_EVENT_DETAIL_TYPE,
   READ_SETS_ADDED_EVENT_DETAIL_TYPE,
   SRM_CLEANUP_EVENT_DETAIL_TYPE,
@@ -58,6 +59,9 @@ function createStateMachineDefinitionSubstitutions(props: BuildSfnProps): {
   definitionSubstitutions['__read_sets_added_event_detail_type__'] =
     READ_SETS_ADDED_EVENT_DETAIL_TYPE;
   definitionSubstitutions['__srm_clean_up_detail_type__'] = SRM_CLEANUP_EVENT_DETAIL_TYPE;
+
+  /* Add in the default reference name */
+  definitionSubstitutions['__default_reference_name__'] = DEFAULT_REFERENCE_NAME;
 
   /* Substitute the event source in the state machine definition */
   definitionSubstitutions['__stack_event_source__'] = STACK_SOURCE;

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -11,7 +11,9 @@ export type SfnName =
   // Post BCLConvert - BSSH Copy
   | 'fastqSetAddReadSet'
   // Post-analysis
-  | 'triggerSomalierExtract';
+  | 'triggerSomalierExtract'
+  // Post-post analysis
+  | 'addMissingFingerprints';
 
 export const sfnNameList: Array<SfnName> = [
   // Pre BCLConvert
@@ -22,6 +24,8 @@ export const sfnNameList: Array<SfnName> = [
   'fastqSetAddReadSet',
   // Post-analysis
   'triggerSomalierExtract',
+  // Post-post-analysis
+  'addMissingFingerprints'
 ];
 
 export interface SfnProps {
@@ -59,6 +63,11 @@ export const triggerSomalierExtractLambdaList: Array<LambdaNameList> = [
   'runExtractFingerprint',
   'getFastqSetIdByLibrary',
 ];
+
+export const addMissingFingerprintsLambdaList: Array<LambdaNameList> = [
+  'findMissingFingerprints',
+  'runExtractFingerprint'
+]
 
 export interface SfnRequirementsProps {
   /* Lambdas */
@@ -109,6 +118,13 @@ export const SfnRequirementsMapType: { [key in SfnName]: SfnRequirementsProps } 
   triggerSomalierExtract: {
     /* Lambdas */
     requiredLambdaNameList: triggerSomalierExtractLambdaList,
+  },
+  // Post-post analysis
+  addMissingFingerprints: {
+    /* Lambdas */
+    requiredLambdaNameList: addMissingFingerprintsLambdaList,
+    /* Sfn specific */
+    needsDistributedMapPolicy: true,
   },
 };
 

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -25,7 +25,7 @@ export const sfnNameList: Array<SfnName> = [
   // Post-analysis
   'triggerSomalierExtract',
   // Post-post-analysis
-  'addMissingFingerprints'
+  'addMissingFingerprints',
 ];
 
 export interface SfnProps {
@@ -66,8 +66,8 @@ export const triggerSomalierExtractLambdaList: Array<LambdaNameList> = [
 
 export const addMissingFingerprintsLambdaList: Array<LambdaNameList> = [
   'findMissingFingerprints',
-  'runExtractFingerprint'
-]
+  'runExtractFingerprint',
+];
 
 export interface SfnRequirementsProps {
   /* Lambdas */


### PR DESCRIPTION
Implements an automated workflow to identify and generate missing somalier fingerprints for fastq sets. This workflow activates after new read sets are processed, ensuring data completeness.

Key changes include:
- **Introduces `addMissingFingerprints` Step Function:** Orchestrates the process, including a waiting period, identifying fastq sets lacking fingerprints, and triggering their extraction in batches.
- **Adds `findMissingFingerprints` Lambda:** Identifies fastq set IDs within an instrument run that do not have associated somalier fingerprint data.
- **Updates `runExtractFingerprint` Lambda:** Makes the BAM URI input optional, allowing fingerprint extraction to proceed when only fastq set ID and reference name are available.
- **Integrates EventBridge rule and target:** A new rule triggers the `addMissingFingerprints` Step Function upon a `Read Sets Added` event, initiating the process with the relevant instrument run ID.